### PR TITLE
feat(cloudformation): Terraform同等のCloudFormationテンプレートを追加

### DIFF
--- a/cloudformation/params/local.example.json
+++ b/cloudformation/params/local.example.json
@@ -1,0 +1,15 @@
+[
+  { "ParameterKey": "TemplateBaseUrl", "ParameterValue": "http://localhost:4566/<bucket>/cloudformation" },
+  { "ParameterKey": "ProjectName", "ParameterValue": "iac-learn" },
+  { "ParameterKey": "AwsRegion", "ParameterValue": "ap-northeast-1" },
+  { "ParameterKey": "VpcCidr", "ParameterValue": "10.10.0.0/16" },
+  { "ParameterKey": "SubnetCidr", "ParameterValue": "10.10.1.0/24" },
+  { "ParameterKey": "LambdaFunctionName", "ParameterValue": "iac-learn-hello-lambda" },
+  { "ParameterKey": "LambdaRuntime", "ParameterValue": "python3.12" },
+  { "ParameterKey": "LambdaHandler", "ParameterValue": "handler.handler" },
+  { "ParameterKey": "LambdaCodeS3Bucket", "ParameterValue": "<local-artifact-bucket>" },
+  { "ParameterKey": "LambdaCodeS3Key", "ParameterValue": "lambda/hello-lambda.zip" },
+  { "ParameterKey": "TaskFamily", "ParameterValue": "iac-learn-hello-fargate" },
+  { "ParameterKey": "ContainerName", "ParameterValue": "hello-fargate" },
+  { "ParameterKey": "ContainerImageUri", "ParameterValue": "iac-learn/fargate:local" }
+]

--- a/cloudformation/params/prod.example.json
+++ b/cloudformation/params/prod.example.json
@@ -1,0 +1,15 @@
+[
+  { "ParameterKey": "TemplateBaseUrl", "ParameterValue": "https://<bucket>.s3.<region>.amazonaws.com/cloudformation" },
+  { "ParameterKey": "ProjectName", "ParameterValue": "iac-learn" },
+  { "ParameterKey": "AwsRegion", "ParameterValue": "ap-northeast-1" },
+  { "ParameterKey": "VpcCidr", "ParameterValue": "10.10.0.0/16" },
+  { "ParameterKey": "SubnetCidr", "ParameterValue": "10.10.1.0/24" },
+  { "ParameterKey": "LambdaFunctionName", "ParameterValue": "iac-learn-hello-lambda" },
+  { "ParameterKey": "LambdaRuntime", "ParameterValue": "python3.12" },
+  { "ParameterKey": "LambdaHandler", "ParameterValue": "handler.handler" },
+  { "ParameterKey": "LambdaCodeS3Bucket", "ParameterValue": "<artifact-bucket>" },
+  { "ParameterKey": "LambdaCodeS3Key", "ParameterValue": "lambda/hello-lambda.zip" },
+  { "ParameterKey": "TaskFamily", "ParameterValue": "iac-learn-hello-fargate" },
+  { "ParameterKey": "ContainerName", "ParameterValue": "hello-fargate" },
+  { "ParameterKey": "ContainerImageUri", "ParameterValue": "<account-id>.dkr.ecr.ap-northeast-1.amazonaws.com/iac-learn-fargate:latest" }
+]

--- a/cloudformation/root.yaml
+++ b/cloudformation/root.yaml
@@ -1,0 +1,101 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Root stack for iac-learn infrastructure.
+
+Parameters:
+  TemplateBaseUrl:
+    Type: String
+    Description: Base URL where nested templates are hosted (without trailing slash).
+  ProjectName:
+    Type: String
+    Default: iac-learn
+  AwsRegion:
+    Type: String
+    Default: ap-northeast-1
+  VpcCidr:
+    Type: String
+    Default: 10.10.0.0/16
+  SubnetCidr:
+    Type: String
+    Default: 10.10.1.0/24
+  LambdaFunctionName:
+    Type: String
+    Default: iac-learn-hello-lambda
+  LambdaRuntime:
+    Type: String
+    Default: python3.12
+  LambdaHandler:
+    Type: String
+    Default: handler.handler
+  LambdaCodeS3Bucket:
+    Type: String
+  LambdaCodeS3Key:
+    Type: String
+  LambdaCodeS3ObjectVersion:
+    Type: String
+    Default: ''
+  TaskFamily:
+    Type: String
+    Default: iac-learn-hello-fargate
+  ContainerName:
+    Type: String
+    Default: hello-fargate
+  ContainerImageUri:
+    Type: String
+
+Resources:
+  NetworkStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateBaseUrl}/stacks/network.yaml
+      Parameters:
+        ProjectName: !Ref ProjectName
+        VpcCidr: !Ref VpcCidr
+        SubnetCidr: !Ref SubnetCidr
+
+  LambdaStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateBaseUrl}/stacks/lambda.yaml
+      Parameters:
+        ProjectName: !Ref ProjectName
+        FunctionName: !Ref LambdaFunctionName
+        Runtime: !Ref LambdaRuntime
+        Handler: !Ref LambdaHandler
+        CodeS3Bucket: !Ref LambdaCodeS3Bucket
+        CodeS3Key: !Ref LambdaCodeS3Key
+        CodeS3ObjectVersion: !Ref LambdaCodeS3ObjectVersion
+
+  EcsFargateStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateBaseUrl}/stacks/ecs-fargate.yaml
+      Parameters:
+        ProjectName: !Ref ProjectName
+        AwsRegion: !Ref AwsRegion
+        TaskFamily: !Ref TaskFamily
+        ContainerName: !Ref ContainerName
+        ContainerImage: !Ref ContainerImageUri
+
+  StepFunctionsStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${TemplateBaseUrl}/stacks/stepfunctions.yaml
+      Parameters:
+        ProjectName: !Ref ProjectName
+        LambdaArn: !GetAtt LambdaStack.Outputs.FunctionArn
+        ClusterArn: !GetAtt EcsFargateStack.Outputs.ClusterArn
+        TaskDefinitionArn: !GetAtt EcsFargateStack.Outputs.TaskDefinitionArn
+        SubnetIds: !GetAtt NetworkStack.Outputs.SubnetIdsCsv
+        SecurityGroupIds: !GetAtt NetworkStack.Outputs.SecurityGroupIdsCsv
+        EcsExecutionRoleArn: !GetAtt EcsFargateStack.Outputs.ExecutionRoleArn
+        EcsTaskRoleArn: !GetAtt EcsFargateStack.Outputs.TaskRoleArn
+
+Outputs:
+  LambdaArn:
+    Value: !GetAtt LambdaStack.Outputs.FunctionArn
+  EcsClusterArn:
+    Value: !GetAtt EcsFargateStack.Outputs.ClusterArn
+  EcsTaskDefinitionArn:
+    Value: !GetAtt EcsFargateStack.Outputs.TaskDefinitionArn
+  StepFunctionsStateMachineArn:
+    Value: !GetAtt StepFunctionsStack.Outputs.StateMachineArn

--- a/cloudformation/stacks/ecs-fargate.yaml
+++ b/cloudformation/stacks/ecs-fargate.yaml
@@ -1,0 +1,87 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: ECS Fargate resources for iac-learn.
+
+Parameters:
+  ProjectName:
+    Type: String
+  AwsRegion:
+    Type: String
+  TaskFamily:
+    Type: String
+  ContainerName:
+    Type: String
+  ContainerImage:
+    Type: String
+
+Resources:
+  EcsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${TaskFamily}"
+      RetentionInDays: 7
+
+  EcsCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${ProjectName}-cluster"
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ProjectName}-${TaskFamily}-execution"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ProjectName}-${TaskFamily}-task"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref TaskFamily
+      RequiresCompatibilities:
+        - FARGATE
+      NetworkMode: awsvpc
+      Cpu: "256"
+      Memory: "512"
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: !Ref ContainerName
+          Image: !Ref ContainerImage
+          Essential: true
+          Command:
+            - python
+            - /app/app.py
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref EcsLogGroup
+              awslogs-region: !Ref AwsRegion
+              awslogs-stream-prefix: ecs
+
+Outputs:
+  ClusterArn:
+    Value: !GetAtt EcsCluster.Arn
+  TaskDefinitionArn:
+    Value: !Ref TaskDefinition
+  ExecutionRoleArn:
+    Value: !GetAtt ExecutionRole.Arn
+  TaskRoleArn:
+    Value: !GetAtt TaskRole.Arn

--- a/cloudformation/stacks/lambda.yaml
+++ b/cloudformation/stacks/lambda.yaml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Lambda resources for iac-learn.
+
+Parameters:
+  ProjectName:
+    Type: String
+  FunctionName:
+    Type: String
+  Runtime:
+    Type: String
+    Default: python3.12
+  Handler:
+    Type: String
+    Default: handler.handler
+  CodeS3Bucket:
+    Type: String
+  CodeS3Key:
+    Type: String
+  CodeS3ObjectVersion:
+    Type: String
+    Default: ""
+
+Conditions:
+  HasCodeVersion: !Not [!Equals [!Ref CodeS3ObjectVersion, ""]]
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ProjectName}-${FunctionName}-exec"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${FunctionName}"
+      RetentionInDays: 7
+
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: !Ref Runtime
+      Handler: !Ref Handler
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: !Ref CodeS3Key
+        S3ObjectVersion: !If
+          - HasCodeVersion
+          - !Ref CodeS3ObjectVersion
+          - !Ref AWS::NoValue
+
+Outputs:
+  FunctionArn:
+    Value: !GetAtt LambdaFunction.Arn
+  FunctionName:
+    Value: !Ref LambdaFunction

--- a/cloudformation/stacks/network.yaml
+++ b/cloudformation/stacks/network.yaml
@@ -1,0 +1,79 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Network resources for iac-learn.
+
+Parameters:
+  ProjectName:
+    Type: String
+  VpcCidr:
+    Type: String
+    Default: 10.10.0.0/16
+  SubnetCidr:
+    Type: String
+    Default: 10.10.1.0/24
+
+Resources:
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectName}-vpc"
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Ref SubnetCidr
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectName}-public-subnet"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${ProjectName}-igw"
+
+  VpcGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+
+  EcsTasksSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for ECS tasks
+      GroupName: !Sub "${ProjectName}-ecs-sg"
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+
+Outputs:
+  SubnetIdsCsv:
+    Value: !Ref PublicSubnet
+  SecurityGroupIdsCsv:
+    Value: !Ref EcsTasksSecurityGroup

--- a/cloudformation/stacks/stepfunctions.yaml
+++ b/cloudformation/stacks/stepfunctions.yaml
@@ -1,0 +1,96 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Step Functions resources for iac-learn.
+
+Parameters:
+  ProjectName:
+    Type: String
+  LambdaArn:
+    Type: String
+  ClusterArn:
+    Type: String
+  TaskDefinitionArn:
+    Type: String
+  SubnetIds:
+    Type: CommaDelimitedList
+  SecurityGroupIds:
+    Type: CommaDelimitedList
+  EcsExecutionRoleArn:
+    Type: String
+  EcsTaskRoleArn:
+    Type: String
+
+Resources:
+  StateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ProjectName}-sfn-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub "${ProjectName}-sfn-policy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Ref LambdaArn
+                  - !Sub "${LambdaArn}:*"
+              - Effect: Allow
+                Action:
+                  - ecs:RunTask
+                Resource:
+                  - !Ref TaskDefinitionArn
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Ref EcsExecutionRoleArn
+                  - !Ref EcsTaskRoleArn
+              - Effect: Allow
+                Action:
+                  - events:PutTargets
+                  - events:PutRule
+                  - events:DescribeRule
+                Resource:
+                  - arn:aws:events:*:*:rule/StepFunctionsGetEventsForECSTaskRule
+
+  StateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Sub "${ProjectName}-workflow"
+      RoleArn: !GetAtt StateMachineRole.Arn
+      Definition:
+        Comment: Hello workflow for Lambda and Fargate
+        StartAt: InvokeLambda
+        States:
+          InvokeLambda:
+            Type: Task
+            Resource: arn:aws:states:::lambda:invoke
+            Parameters:
+              FunctionName: !Ref LambdaArn
+              Payload.$: $
+            Next: RunFargateTask
+          RunFargateTask:
+            Type: Task
+            Resource: arn:aws:states:::ecs:runTask.sync
+            Parameters:
+              LaunchType: FARGATE
+              Cluster: !Ref ClusterArn
+              TaskDefinition: !Ref TaskDefinitionArn
+              NetworkConfiguration:
+                AwsvpcConfiguration:
+                  Subnets: !Ref SubnetIds
+                  SecurityGroups: !Ref SecurityGroupIds
+                  AssignPublicIp: ENABLED
+            End: true
+
+Outputs:
+  StateMachineArn:
+    Value: !Ref StateMachine


### PR DESCRIPTION
## 概要
Terraform で定義しているインフラ（network / lambda / ecs_fargate / stepfunctions）と比較できるよう、CloudFormation の同等テンプレートを追加しました。

## 変更内容
- `cloudformation/root.yaml` を追加（nested stack のエントリ）
- `cloudformation/stacks/` に以下を追加
  - `network.yaml`
  - `lambda.yaml`
  - `ecs-fargate.yaml`
  - `stepfunctions.yaml`
- `cloudformation/params/` にパラメータ例を追加
  - `prod.example.json`
  - `local.example.json`
- `README.md` に CloudFormation の事前準備・検証・デプロイ手順を追記

## 検証
- `aws cloudformation validate-template` を実行しようとしましたが、ローカル環境で AWS 認証情報が未設定のため実行完了できていません（手順は README に記載済み）。

Closes #3