### PR TITLE
chore: 開発環境を改善する

### DIFF
--- a/.devcontainer/docker-compose.workspace.yml
+++ b/.devcontainer/docker-compose.workspace.yml
@@ -6,6 +6,7 @@ x-workspace: &workspace
     - ..:/workspaces/iac-learn
     - /var/run/docker.sock:/var/run/docker.sock
   environment:
+    - AWS_DEFAULT_REGION=ap-northeast-1
     - TF_VAR_localstack_endpoint=http://localstack:4566
     - LOCALSTACK_HOST=localstack:4566
     - LOCALSTACK_HOSTNAME=localstack

--- a/.devcontainer/vscode/devcontainer.json
+++ b/.devcontainer/vscode/devcontainer.json
@@ -30,11 +30,23 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "python.defaultInterpreterPath": "/home/vscode/.venv/bin/python"
+        "python.defaultInterpreterPath": "/home/vscode/.venv/bin/python",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        },
+        "[terraform]": {
+          "editor.defaultFormatter": "hashicorp.terraform",
+          "editor.formatOnSave": true
+        }
       },
       "extensions": [
+        "ms-python.python",
         "hashicorp.terraform",
-        "ms-python.python"
+        "tamasfe.even-better-toml",
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "eamodio.gitlens"
       ]
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,10 @@ terraform/environments/prod/terraform.tfvars
 
 # IDE
 .idea/
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/launch.json
 *.swp
 *.swo
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "hashicorp.terraform",
+    "tamasfe.even-better-toml",
+    "charliermarsh.ruff",
+    "amazonwebservices.aws-toolkit-vscode",
+    "eamodio.gitlens"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Fargate アプリ (デバッグ)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "fargate.app",
+      "cwd": "${workspaceFolder}",
+      "env": { "PYTHONPATH": "${workspaceFolder}/src" }
+    },
+    {
+      "name": "pytest (全テスト)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["tests/", "-v"],
+      "cwd": "${workspaceFolder}",
+      "env": { "PYTHONPATH": "${workspaceFolder}/src" }
+    },
+    {
+      "name": "pytest (現在のファイル)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["${file}", "-v"],
+      "cwd": "${workspaceFolder}",
+      "env": { "PYTHONPATH": "${workspaceFolder}/src" }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.unittestEnabled": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,11 @@
      - 設定の `rev` を更新
      - 先に設定ファイルをコミット
 
+4. Terraform
+   - `.tf` ファイルを変更したら必ず `terraform fmt -recursive terraform/` を実行する
+   - 確認のみ: `terraform fmt -check -recursive terraform/`
+   - pre-commit には Terraform フォーマッタが含まれないため、手動実行が必要
+
 ## エラー解決
 
 1. CI 失敗

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ uv run --frozen pyright
 
 pre-commit でも同等のチェックを実行できます。
 
+### Terraform フォーマット
+
+`.tf` ファイルを変更した場合は、コミット前に必ずフォーマッタを適用してください。
+
+```bash
+terraform fmt -recursive terraform/
+```
+
+確認のみ（変更しない）:
+
+```bash
+terraform fmt -check -recursive terraform/
+```
+
 ```bash
 uv run --frozen pre-commit run --all-files
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = []
 [dependency-groups]
 dev = [
   "awscli-local>=0.22.2",
+  "boto3>=1.35.0",
   "pre-commit>=4.5.1",
   "pyright>=1.1.408",
   "pytest>=9.0.2",
@@ -18,7 +19,7 @@ dev = [
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
-addopts = "--cov=src --cov-branch --cov-report=term-missing"
+addopts = "--cov=src --cov-branch --cov-report=term-missing --ignore=tests/integration"
 
 [tool.coverage.report]
 fail_under = 100

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+import os
+import socket
+
+import pytest
+
+
+def _is_localstack_available() -> bool:
+    """LocalStack が起動しているか確認する。"""
+    localstack_host = os.environ.get("LOCALSTACK_HOST", "localhost:4566")
+    host, _, port_str = localstack_host.partition(":")
+    port = int(port_str) if port_str else 4566
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """LocalStack が利用不可な場合は統合テストをスキップする。"""
+    if _is_localstack_available():
+        return
+    skip_marker = pytest.mark.skip(reason="LocalStack が起動していません")
+    for item in items:
+        item.add_marker(skip_marker)

--- a/tests/integration/test_lambda_invoke.py
+++ b/tests/integration/test_lambda_invoke.py
@@ -1,0 +1,31 @@
+import json
+import os
+
+import boto3
+
+
+def _get_endpoint_url() -> str:
+    """LocalStack エンドポイント URL を返す。"""
+    host = os.environ.get("LOCALSTACK_HOST", "localhost:4566")
+    return f"http://{host}"
+
+
+def test_hello_lambda_returns_expected_response() -> None:
+    """デプロイ済み Lambda を呼び出し、期待するレスポンスを確認する。"""
+    client = boto3.client(
+        "lambda",
+        region_name="ap-northeast-1",
+        endpoint_url=_get_endpoint_url(),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    payload = {"hello": "world"}
+
+    response = client.invoke(
+        FunctionName="iac-learn-hello-lambda",
+        Payload=json.dumps(payload).encode(),
+    )
+
+    result = json.loads(response["Payload"].read())
+    assert result["message"] == "Hello from Lambda!"
+    assert result["input"] == payload

--- a/uv.lock
+++ b/uv.lock
@@ -170,6 +170,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "awscli-local" },
+    { name = "boto3" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -183,6 +184,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "awscli-local", specifier = ">=0.22.2" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
## 概要

VS Code / Dev Container の開発体験を統一し、LocalStack 統合テストの雛形を整備する。

## 変更内容

### VS Code 設定の管理
`.vscode/` を許可リスト形式の `.gitignore` でバージョン管理対象に変更し、3ファイルを追加した。

- `extensions.json` — 推奨拡張機能を定義（Python, Terraform, Ruff, GitLens など）
- `settings.json` — pytest をデフォルトテストランナーに設定
- `launch.json` — Fargate アプリ・pytest 全件・現在ファイルの3パターンのデバッグ設定

### Dev Container の改善
- devcontainer に拡張機能・フォーマッタ設定（保存時フォーマット）を追加し、VS Code の設定と一致させた
- `AWS_DEFAULT_REGION=ap-northeast-1` をワークスペースコンテナの環境変数に追加し、boto3 や AWS CLI がリージョン指定なしで動作するようにした

### LocalStack 統合テスト雛形
- `boto3` を dev 依存に追加
- `tests/integration/conftest.py` — `LOCALSTACK_HOST` に接続できない場合にディレクトリ内テストを自動スキップ
- `tests/integration/test_lambda_invoke.py` — `iac-learn-hello-lambda` を呼び出して期待するレスポンスを検証
- `--ignore=tests/integration` を pytest オプションに追加し、CI のユニットテスト・カバレッジ要件に影響しないようにした

### ドキュメント
`README.md` と `CLAUDE.md` に Terraform フォーマット（`terraform fmt`）の手順を追記した。pre-commit に Terraform フォーマッタが含まれないため、手動実行のルールを明文化した。

Closes #9