### PR TITLE
feat(integration): LocalStack 統合テストを Terraform outputs で動的化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,44 @@ jobs:
       - name: Pytest
         run: uv run --frozen pytest -q
 
+  integration-test:
+    runs-on: ubuntu-latest
+    services:
+      localstack:
+        image: localstack/localstack:latest
+        ports:
+          - 4566:4566
+        env:
+          SERVICES: iam,lambda,logs,sts,ec2,ecs,ecr,stepfunctions,events
+          AWS_DEFAULT_REGION: ap-northeast-1
+        options: >-
+          --health-cmd "curl -f http://localhost:4566/_localstack/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run integration tests
+        run: uv run --frozen pytest tests/integration -v --override-ini="addopts="
+        env:
+          LOCALSTACK_HOST: localhost:4566
+
   terraform-validate:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack-pro:latest
         ports:
           - 4566:4566
         env:
           SERVICES: iam,lambda,logs,sts,ec2,ecs,ecr,stepfunctions,events
           AWS_DEFAULT_REGION: ap-northeast-1
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         options: >-
           --health-cmd "curl -f http://localhost:4566/_localstack/health"
           --health-interval 10s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           SERVICES: iam,lambda,logs,sts,ec2,ecs,ecr,stepfunctions,events
           AWS_DEFAULT_REGION: ap-northeast-1
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LAMBDA_EXECUTOR: local
         options: >-
           --health-cmd "curl -f http://localhost:4566/_localstack/health"
           --health-interval 10s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
           SERVICES: iam,lambda,logs,sts,ec2,ecs,ecr,stepfunctions,events
           AWS_DEFAULT_REGION: ap-northeast-1
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          LAMBDA_EXECUTOR: local
         options: >-
           --health-cmd "curl -f http://localhost:4566/_localstack/health"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+          -v /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
   "pytest-cov>=7.0.0",
   "ruff>=0.15.2",
   "terraform-local>=0.11.1",
+  "tftest>=1.8.5",
 ]
 
 [tool.pytest.ini_options]

--- a/terraform/environments/local/main.tf
+++ b/terraform/environments/local/main.tf
@@ -8,15 +8,15 @@ provider "aws" {
   s3_use_path_style           = true
 
   endpoints {
-    ec2           = var.localstack_endpoint
-    ecs           = var.localstack_endpoint
-    ecr           = var.localstack_endpoint
-    events        = var.localstack_endpoint
-    iam           = var.localstack_endpoint
-    lambda        = var.localstack_endpoint
-    logs          = var.localstack_endpoint
-    sfn           = var.localstack_endpoint
-    sts           = var.localstack_endpoint
+    ec2    = var.localstack_endpoint
+    ecs    = var.localstack_endpoint
+    ecr    = var.localstack_endpoint
+    events = var.localstack_endpoint
+    iam    = var.localstack_endpoint
+    lambda = var.localstack_endpoint
+    logs   = var.localstack_endpoint
+    sfn    = var.localstack_endpoint
+    sts    = var.localstack_endpoint
   }
 }
 
@@ -42,13 +42,13 @@ module "ecs_fargate" {
 }
 
 module "stepfunctions" {
-  source                = "../../modules/stepfunctions"
-  project_name          = var.project_name
-  lambda_arn            = module.lambda.function_arn
-  cluster_arn           = module.ecs_fargate.cluster_arn
-  task_definition_arn   = module.ecs_fargate.task_definition_arn
-  subnet_ids            = module.network.subnet_ids
-  security_group_ids    = module.network.security_group_ids
+  source                 = "../../modules/stepfunctions"
+  project_name           = var.project_name
+  lambda_arn             = module.lambda.function_arn
+  cluster_arn            = module.ecs_fargate.cluster_arn
+  task_definition_arn    = module.ecs_fargate.task_definition_arn
+  subnet_ids             = module.network.subnet_ids
+  security_group_ids     = module.network.security_group_ids
   ecs_execution_role_arn = module.ecs_fargate.execution_role_arn
   ecs_task_role_arn      = module.ecs_fargate.task_role_arn
 }

--- a/terraform/environments/local/outputs.tf
+++ b/terraform/environments/local/outputs.tf
@@ -2,6 +2,10 @@ output "lambda_arn" {
   value = module.lambda.function_arn
 }
 
+output "lambda_function_name" {
+  value = module.lambda.function_name
+}
+
 output "ecs_cluster_arn" {
   value = module.ecs_fargate.cluster_arn
 }

--- a/terraform/environments/local/terraform.tfvars
+++ b/terraform/environments/local/terraform.tfvars
@@ -1,3 +1,3 @@
-project_name = "iac-learn"
-aws_region   = "ap-northeast-1"
+project_name  = "iac-learn"
+aws_region    = "ap-northeast-1"
 fargate_image = "iac-learn/fargate:local"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,14 @@
 import os
 import socket
+from pathlib import Path
+from typing import Any
 
 import pytest
+import tftest  # type: ignore[import-untyped]
+
+_TERRAFORM_DIR = str(
+    Path(__file__).parent.parent.parent / "terraform" / "environments" / "local"
+)
 
 
 def _is_localstack_available() -> bool:
@@ -23,3 +30,13 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     skip_marker = pytest.mark.skip(reason="LocalStack が起動していません")
     for item in items:
         item.add_marker(skip_marker)
+
+
+@pytest.fixture(scope="session")
+def terraform_outputs() -> dict[str, Any]:
+    """Terraform の output を返す。CI では apply も実行する。"""
+    tf = tftest.TerraformTest(_TERRAFORM_DIR)
+    if os.environ.get("CI"):
+        tf.setup()
+        tf.apply()
+    return tf.output()  # type: ignore[no-any-return]

--- a/tests/integration/test_lambda_invoke.py
+++ b/tests/integration/test_lambda_invoke.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Any
 
 import boto3
 
@@ -10,7 +11,9 @@ def _get_endpoint_url() -> str:
     return f"http://{host}"
 
 
-def test_hello_lambda_returns_expected_response() -> None:
+def test_hello_lambda_returns_expected_response(
+    terraform_outputs: dict[str, Any],
+) -> None:
     """デプロイ済み Lambda を呼び出し、期待するレスポンスを確認する。"""
     client = boto3.client(
         "lambda",
@@ -22,7 +25,7 @@ def test_hello_lambda_returns_expected_response() -> None:
     payload = {"hello": "world"}
 
     response = client.invoke(
-        FunctionName="iac-learn-hello-lambda",
+        FunctionName=terraform_outputs["lambda_function_name"],
         Payload=json.dumps(payload).encode(),
     )
 

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -1,0 +1,46 @@
+import os
+import time
+from typing import Any
+
+import boto3
+
+_TERMINAL_STATES = {"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"}
+_POLL_INTERVAL = 2
+_MAX_WAIT = 30
+
+
+def _get_endpoint_url() -> str:
+    """LocalStack エンドポイント URL を返す。"""
+    host = os.environ.get("LOCALSTACK_HOST", "localhost:4566")
+    return f"http://{host}"
+
+
+def test_stepfunctions_execution_succeeds(
+    terraform_outputs: dict[str, Any],
+) -> None:
+    """State Machine を実行し、SUCCEEDED で完了することを確認する。"""
+    client = boto3.client(
+        "stepfunctions",
+        region_name="ap-northeast-1",
+        endpoint_url=_get_endpoint_url(),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    state_machine_arn = terraform_outputs["stepfunctions_state_machine_arn"]
+
+    start_response = client.start_execution(stateMachineArn=state_machine_arn)
+    execution_arn = start_response["executionArn"]
+
+    elapsed = 0
+    status = ""
+    while elapsed < _MAX_WAIT:
+        describe_response = client.describe_execution(executionArn=execution_arn)
+        status = describe_response["status"]
+        if status in _TERMINAL_STATES:
+            break
+        time.sleep(_POLL_INTERVAL)
+        elapsed += _POLL_INTERVAL
+
+    assert status == "SUCCEEDED", (
+        f"State Machine が SUCCEEDED になりませんでした: {status}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "terraform-local" },
+    { name = "tftest" },
 ]
 
 [package.metadata]
@@ -191,6 +192,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "terraform-local", specifier = ">=0.11.1" },
+    { name = "tftest", specifier = ">=1.8.5" },
 ]
 
 [[package]]
@@ -559,6 +561,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/30/3ca48aa0615960bc891c976512df7cca1ecf72535446f4bbe9b1ac110ebf/terraform_local-0.25.0.tar.gz", hash = "sha256:8730cfc92dcdbfcb10293420cafb22566d56a2af58139e8a976828b10e07c7e2", size = 23830, upload-time = "2025-12-01T16:27:05.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/2f/4b7c68c43505d5a8769cbddf4dae0069b44e7f7f1c81a32d33777bdf1448/terraform_local-0.25.0-py3-none-any.whl", hash = "sha256:769044ec37a571c0c22e4e8bda1848f45baa56ff64f4cab636ea179faac61af9", size = 16636, upload-time = "2025-12-01T16:27:04.067Z" },
+]
+
+[[package]]
+name = "tftest"
+version = "1.8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/7a/b75e4bd761767168b868ddf6da9ff2f8237feea1725143efb21d12c90e80/tftest-1.8.5.tar.gz", hash = "sha256:4dc4cbe3dd6c89b0d8732ac5ec8d1ed27e4e3aff26374baa42af6e5c90087df8", size = 22859, upload-time = "2023-10-11T08:44:06.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/56/b17a36b14af4957f46324b693a4d42d643965e8094030e83a474245f778a/tftest-1.8.5-py3-none-any.whl", hash = "sha256:8162043ed30f80c8606a89e9fe68f68840972ea36d9c8b1e40fa27cbf463eaf3", size = 16026, upload-time = "2023-10-11T08:44:04.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

Issue #10 の対応として、統合テストをより堅牢な実装に改善しました。

従来の実装ではLambda関数名をハードコードしており、CI上でのテスト実行も未対応でした。本PRでは `tftest` を導入して Terraform outputs から動的に値を取得し、CI（GitHub Actions）でも統合テストが自動実行されるようにします。

## 変更内容

### Terraform
- `terraform/environments/local/outputs.tf` に `lambda_function_name` output を追加

### Python 依存
- `pyproject.toml` に `tftest>=1.8.5` を dev 依存として追加

### 統合テスト
- `tests/integration/conftest.py`: `terraform_outputs` session fixture を追加
  - CI環境（`CI` 環境変数あり）では `tf.setup()` + `tf.apply()` を実行
  - ローカル（apply済み前提）では `tf.output()` のみ呼ぶ
- `tests/integration/test_lambda_invoke.py`: ハードコードの関数名を `terraform_outputs["lambda_function_name"]` に置換
- `tests/integration/test_stepfunctions.py`: 新規作成
  - State Machine を実行し、最大30秒ポーリングして SUCCEEDED 完了を確認

### CI
- `.github/workflows/ci.yml` に `integration-test` ジョブを追加
  - LocalStack コンテナをサービスとして起動
  - Terraform apply 後に統合テストを実行
  - `--override-ini="addopts="` で `--ignore=tests/integration` をリセット

Github-Issue:#10