### PR TITLE
ci: integration-test ジョブの Setup Python を削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
       - name: Sync dependencies
         run: uv sync --frozen --group dev
 


### PR DESCRIPTION
## 概要

#14 のマージ後、#12 のマージで追加された `integration-test` ジョブに `actions/setup-python@v5` が残っていたため削除する。

## 変更内容

`integration-test` ジョブの `Setup Python` ステップを削除。`uv sync --frozen` が `.python-version`（`3.14`）を読み取り Python を自動インストールするため不要。

Closes #13